### PR TITLE
Add missing return statements

### DIFF
--- a/src/MultipleManipulatorsModelCorrection.cpp
+++ b/src/MultipleManipulatorsModelCorrection.cpp
@@ -51,6 +51,7 @@ bool MultipleManipulatorsModelCorrection::configureFromFile(
     start_indexes_.push_back(start);
     end_indexes_.push_back(end);
   }
+  return true;
 }
 
 

--- a/src/RrtPathPlanner.cpp
+++ b/src/RrtPathPlanner.cpp
@@ -178,6 +178,8 @@ bool RrtPathPlanner::configureFromFile(string config_filename)
   planner_configuration_.smooth_bspline_max_steps =
     config["path_planner"]["path_simplifier"]["smooth_b_spline"]["max_steps"].as<double>();
   //printRrtStarConfig(planner_configuration_);
+
+  return true;
 }
 
 bool RrtPathPlanner::planPath(Eigen::MatrixXd positions)

--- a/src/ToppraTrajectory.cpp
+++ b/src/ToppraTrajectory.cpp
@@ -64,12 +64,14 @@ bool ToppraTrajectory::configureFromFile(string config_filename)
 
     // Set up sampling frequency
     sampling_frequency_ = config["trajectory_planner"]["toppra_trajectory"]["sampling_frequency"].as<double>();
+
   }
   else{
     cout << "Error in config: Velocity and acceleration constraints must have ";
     cout << "the same number of elements." << endl;
     exit(0);
   }
+  return true;
 }
 
 bool ToppraTrajectory::generateTrajectory(Eigen::MatrixXd positions)


### PR DESCRIPTION
Without adding explicit return statements to bool methods the global planner crashes with the following error:
```
free(): double free detected in tcache 2
```
On Ubuntu 20.04, ROS Noetic.