### PR TITLE
[GlobalPlannerRosInterface] Separate adding of velocities/accelerations from position values.

### DIFF
--- a/src/GlobalPlannerRosInterface.cpp
+++ b/src/GlobalPlannerRosInterface.cpp
@@ -1072,6 +1072,16 @@ Trajectory GlobalPlannerRosInterface::jointTrajectoryToTrajectory(
       eigen_trajectory.acceleration(i,j) = joint_trajectory.points[i].accelerations[j];
     }
 
+    if (joint_trajectory_point.velocities.size() != joint_trajectory_point.positions.size() ||
+      joint_trajectory_point.accelerations.size() != joint_trajectory_point.positions.size())
+    {
+      ROS_WARN_THROTTLE(2.0, "[GlobalPlannerRosInterface::jointTrajectoryToTrajectory] "
+                             "fields are not the same size! Pos: %d, Vel: %d, Acc: %d.",
+                             joint_trajectory_point.positions.size(), 
+                             joint_trajectory_point.velocities.size(),
+                             joint_trajectory_point.accelerations.size());
+    }
+    
     eigen_trajectory.time(i) = joint_trajectory.points[i].time_from_start.toSec();
   }
 


### PR DESCRIPTION
JointTrajectory might not have the same amount of position values as the velocities or accelerations (e.g. we want to have collision checking with only positions).

Avoid segmentation faults by appending values to each field separately.