### PR TITLE
Add loading paths from environment and absolute path filenames

### DIFF
--- a/include/larics_motion_planning/MotionPlanningUtil.h
+++ b/include/larics_motion_planning/MotionPlanningUtil.h
@@ -1,0 +1,71 @@
+#ifndef CONFIG_PATH_UTIL_H
+#define CONFIG_PATH_UTIL_H
+
+#include <string>
+#include <fstream>
+
+namespace motion_util {
+
+/**
+ * @brief Return true if file exists, otherwise false.
+ *
+ */
+inline bool fileExists(const std::string& name)
+{
+  std::ifstream f(name.c_str());
+  return f.good();
+}
+
+/**
+ * @brief Get the User Prefix object
+ * 
+ */
+inline std::string getUserPrefix()
+{
+  if (getenv("ABSOLUTE_CONFIG") != nullptr)
+  {
+    return {};
+  }
+
+  std::string username = "/home/";
+  username = username + getenv("USER") + "/";
+  return username;
+}
+
+/**
+ * @brief Load path using get_param functor. If it fails try the
+ * backup path using a defined environment variable. If that fails - throw.
+ *
+ */
+template<typename F> std::string loadPathOrThrow(F get_path, const char* env_backup, const std::string& param_name="config")
+{
+  std::string config_file;
+  try {
+
+    // Try loading using the given functor...
+    config_file = get_path();
+
+  } catch (const std::exception& e) {
+
+    // If it throws, notify the user...
+    std::cerr << "Error while trying to load " << param_name << " path: " << e.what() << '\n';
+    std::cout
+      << "Try to load through environment variable ${" << env_backup << "}\n";
+
+    // ... and try loading using the env file
+    auto* config_ptr = getenv(env_backup);
+
+    if (config_ptr == nullptr) {
+      throw std::runtime_error("Did not get " + param_name + " file, nor ${"
+                               + std::string(env_backup) + "} env. Throwing...");
+    }
+
+    config_file = std::string(config_ptr);
+  }
+
+  std::cout << "Loaded path [" << param_name << "]:\n" << config_file << "\n";
+  return config_file;
+}
+}// namespace motion_util
+
+#endif /*CONFIG_PATH_UTIL_H*/

--- a/src/GlobalPlanner.cpp
+++ b/src/GlobalPlanner.cpp
@@ -3,11 +3,9 @@
 
 GlobalPlanner::GlobalPlanner(string config_filename)
 {
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  size_t found = config_filename.find(username);
+  size_t found = config_filename.find(motion_util::getUserPrefix());
   if (found != string::npos) configureFromFile(config_filename);
-  else configureFromFile(username + config_filename);
+  else configureFromFile(motion_util::getUserPrefix() + config_filename);
 }
 
 bool GlobalPlanner::configureFromFile(string config_filename)

--- a/src/MultipleManipulatorsKinematics.cpp
+++ b/src/MultipleManipulatorsKinematics.cpp
@@ -1,10 +1,9 @@
 #include <larics_motion_planning/MultipleManipulatorsKinematics.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 MultipleManipulatorsKinematics::MultipleManipulatorsKinematics(string config_filename)
 {
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  configureFromFile(username + config_filename);
+  configureFromFile(motion_util::getUserPrefix() + config_filename);
 }
 
 bool MultipleManipulatorsKinematics::configureFromFile(string config_filename)

--- a/src/MultipleManipulatorsModelCorrection.cpp
+++ b/src/MultipleManipulatorsModelCorrection.cpp
@@ -1,4 +1,5 @@
 #include <larics_motion_planning/MultipleManipulatorsModelCorrection.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 MultipleManipulatorsModelCorrection::MultipleManipulatorsModelCorrection(
   string config_filename, shared_ptr<KinematicsInterface> kinematics)
@@ -6,10 +7,7 @@ MultipleManipulatorsModelCorrection::MultipleManipulatorsModelCorrection(
   // Immediately cast into multiple manipulator kinematics. This is not pretty
   // but it is necessary to get single manipulator joint positions.
   kinematics_ = dynamic_pointer_cast<MultipleManipulatorsKinematics>(kinematics);
-
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  configureFromFile(username + config_filename);
+  configureFromFile(motion_util::getUserPrefix() + config_filename);
 }
 
 bool MultipleManipulatorsModelCorrection::configureFromFile(

--- a/src/OctomapMap.cpp
+++ b/src/OctomapMap.cpp
@@ -1,6 +1,7 @@
 /// \file OctomapMap.cpp
 
 #include <larics_motion_planning/OctomapMap.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 OctomapMap::OctomapMap(double resolution) :
 map_(make_unique<octomap::OcTree>(resolution))
@@ -13,9 +14,7 @@ map_(make_unique<octomap::OcTree>(resolution))
 OctomapMap::OctomapMap(string octomap_config_file)
 {
   // Configures the map from yaml file.
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  configureFromFile(username + octomap_config_file);
+  configureFromFile(motion_util::getUserPrefix() + octomap_config_file);
 }
 
 OctomapMap::~OctomapMap()
@@ -53,10 +52,14 @@ bool OctomapMap::configureFromFile(string config_filename)
   YAML::Node config = YAML::LoadFile(config_filename);
 
   // Load map from path provided in file.
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  map_ = make_unique<octomap::OcTree>(username +
-    config["octomap"]["path_to_file"].as<string>());
+  map_ = make_unique<octomap::OcTree>(
+    motion_util::getUserPrefix() +
+    motion_util::loadPathOrThrow(
+      [&](){ return config["octomap"]["path_to_file"].as<string>(); },
+      "OCTOMAP_FILE",
+      "octomap/path_to_file"
+      )
+    );
   // Set search depth from file.
   search_depth_ = config["octomap"]["search_depth"].as<int>();
   return true;

--- a/src/ParabolicAirdropPlanner.cpp
+++ b/src/ParabolicAirdropPlanner.cpp
@@ -1,4 +1,5 @@
 #include <larics_motion_planning/ParabolicAirdropPlanner.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 ParabolicAirdropPlanner::ParabolicAirdropPlanner(
   string config_filename):GlobalPlanner(config_filename)
@@ -14,11 +15,15 @@ ParabolicAirdropPlanner::ParabolicAirdropPlanner(
   //alpha_.resize(10);
   //alpha_ << 20.0, 25.0, 15.0, 30.0, 10.0, 5.0, 0.0, 35.0, 40.0, 45.0;
 
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  size_t found = config_filename.find(username);
-  if (found != string::npos) configureParabolicAirdropFromFile(config_filename);
-  else configureParabolicAirdropFromFile(username + config_filename);
+  size_t found = config_filename.find(motion_util::getUserPrefix());
+  if (found != string::npos) 
+  {
+    configureParabolicAirdropFromFile(config_filename);
+  }
+  else 
+  {
+    configureParabolicAirdropFromFile(motion_util::getUserPrefix() + config_filename);
+  }
 }
 
 bool ParabolicAirdropPlanner::configureParabolicAirdropFromFile(

--- a/src/RrtPathPlanner.cpp
+++ b/src/RrtPathPlanner.cpp
@@ -1,4 +1,5 @@
 #include <larics_motion_planning/RrtPathPlanner.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 #include <ctime>
 
 void printRrtStarConfig(RrtStarConfig config)
@@ -45,9 +46,7 @@ RrtPathPlanner::RrtPathPlanner(string config_filename,
   shared_ptr<StateValidityCheckerInterface> validity_checker)
 {
   state_validity_checker_ = validity_checker;
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  configureFromFile(username + config_filename);
+  configureFromFile(motion_util::getUserPrefix() + config_filename);
   path_length_ = 0.0;
 }
 

--- a/src/SimpleStateValidityCheckers.cpp
+++ b/src/SimpleStateValidityCheckers.cpp
@@ -1,4 +1,5 @@
 #include <larics_motion_planning/SimpleStateValidityCheckers.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 SimpleStateValidityCheckers::SimpleStateValidityCheckers(
   string config_filename, shared_ptr<MapInterface> map, string type)
@@ -6,9 +7,7 @@ SimpleStateValidityCheckers::SimpleStateValidityCheckers(
   map_ = map;
   checker_type_ = string(type);
 
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-  configureFromFile(username + config_filename);
+  configureFromFile(motion_util::getUserPrefix() + config_filename);
 
   if (checker_type_.compare("ball") == 0) points_ = generateBall();
   else if (checker_type_.compare("sphere") == 0) points_ = generateSphere();

--- a/src/ToppraTrajectory.cpp
+++ b/src/ToppraTrajectory.cpp
@@ -1,17 +1,15 @@
 #include <larics_motion_planning/ToppraTrajectory.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 ToppraTrajectory::ToppraTrajectory(string config_filename) :
 TrajectoryInterface(config_filename)
 {
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-
   // Set up node handle and create service
   nh_ = ros::NodeHandle();
   generate_trajectory_client_ = nh_.serviceClient<topp_ros::GenerateTrajectory>(
     "generate_toppra_trajectory");
 
-  configureFromFile(username + config_filename);
+  configureFromFile(motion_util::getUserPrefix() + config_filename);
 }
 
 ToppraTrajectory::ToppraTrajectory(Eigen::MatrixXd config_matrix, double sampling_frequency) :

--- a/src/TrajectoryInterface.cpp
+++ b/src/TrajectoryInterface.cpp
@@ -1,4 +1,5 @@
 #include <larics_motion_planning/TrajectoryInterface.h>
+#include <larics_motion_planning/MotionPlanningUtil.h>
 
 TrajectoryInterface::TrajectoryInterface()
 {
@@ -8,15 +9,11 @@ TrajectoryInterface::TrajectoryInterface()
 TrajectoryInterface::TrajectoryInterface(string config_filename)
 {
   cout << "Hello from TrajectoryInterface" << endl;
-  cout << config_filename << endl;
-
-  string username = "/home/";
-  username = username + getenv("USER") + "/";
-
   cout << "Initializing trajectory interface from file:" << endl;
   cout << "  " << config_filename << endl;
+
   // Open yaml file with configuration
-  YAML::Node config = YAML::LoadFile(username + config_filename);
+  YAML::Node config = YAML::LoadFile(motion_util::getUserPrefix() + config_filename);
 
   // Load everything from yaml file
   // Indexes for constant velocity reparametrization


### PR DESCRIPTION
- Add an option to load paths via the following environment variables as follows:
```bash
export MAP_CONFIG=$(rospack find icuas22_competition)/config/global_planner.yaml
export TRAJ_CONFIG=$(rospack find icuas22_competition)/config/global_planner.yaml
export STATE_VALIDITY_CONFIG=$(rospack find icuas22_competition)/config/global_planner.yaml
export PATH_PLANNER_CONFIG=$(rospack find icuas22_competition)/config/global_planner.yaml
export MODEL_CORRECTION_CONFIG=$(rospack find larics_motion_planning)/config/model_correction_config_example.yaml
export OCTOMAP_FILE=$(rospack find larics_motion_planning)/config/empty_map.binvox.bt
```  

- If the ```ABSOLUTE_CONFIG``` environment variable is defined all loaded config paths (from yaml or otherwise) will be regarded as absolute